### PR TITLE
Feature/use_map [Create] show post info

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,3 +1,4 @@
 {
-  "extends": ["plugin:prettier/recommended"]
+  "extends": ["plugin:prettier/recommended"],
+  "parser": "babel-eslint"
 }

--- a/components/Map/index.tsx
+++ b/components/Map/index.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useCallback } from 'react';
-import { useMap } from '@contexts/MapContext';
+import { useMap } from '@contexts/Map/MapContext';
 
 const Map = () => {
   const { initializeMap } = useMap();

--- a/contexts/MapContext.tsx
+++ b/contexts/MapContext.tsx
@@ -113,6 +113,7 @@ export const MapProvider = ({ children }: { children: React.ReactChild }) => {
       latitude: myMarker?.getPosition().getLat().toFixed(6) ?? '',
       longitude: myMarker?.getPosition().getLng().toFixed(6) ?? '',
     }));
+
     myMarker?.setMap(map);
 
     /* 특정 포스트 마커 생성 */
@@ -169,18 +170,15 @@ export const MapProvider = ({ children }: { children: React.ReactChild }) => {
       };
       navigator?.geolocation.getCurrentPosition(onSuccess, onError);
     }
-  }, [map, myMarker]);
+  }, []);
 
   /* 특정 포스트 위치로 지도 중심 좌표 변경 with 특정 포스트 마커 */
-  const moveCenterToPost = useCallback(
-    (latitude: number, longitude: number) => {
-      if (map && postMarker) {
-        postMarker.setMap(null);
-        setMapCenter(latitude, longitude, postMarker);
-      }
-    },
-    [map, postMarker],
-  );
+  const moveCenterToPost = useCallback((latitude: number, longitude: number) => {
+    if (map && postMarker) {
+      postMarker.setMap(null);
+      setMapCenter(latitude, longitude, postMarker);
+    }
+  }, []);
 
   /* 내가 찍은 마커 위치 가져오기 */
   const getMyPosition = useCallback(() => myPosition, [myPosition]);

--- a/contexts/MapContext.tsx
+++ b/contexts/MapContext.tsx
@@ -3,7 +3,6 @@ import { useNavigate } from 'react-router-dom';
 import fetcher from '@utils/fetcher';
 import { IPost } from '@typings/db';
 import { showPostInfo } from './infowindow';
-import { stringify } from 'querystring';
 const { kakao } = window;
 
 interface IMapContext {
@@ -12,8 +11,12 @@ interface IMapContext {
   initializeMap: (container: HTMLElement, latitude: number, longitude: number) => void;
   moveCenterToMe: () => void;
   moveCenterToPost: (latitude: number, longitude: number) => void;
-  getMyPosition: () => { latitude: string | undefined; longitude: string | undefined };
+  getMyPosition: () => { latitude: string; longitude: string };
 }
+
+let map: kakao.maps.Map | null;
+let myMarker: kakao.maps.Marker | null;
+let postMarker: kakao.maps.Marker | null;
 
 const MapContext = createContext<IMapContext>({
   map: null,
@@ -26,15 +29,12 @@ const MapContext = createContext<IMapContext>({
 
 export const MapProvider = ({ children }: { children: React.ReactChild }) => {
   const navigate = useNavigate();
-  const [_, rerenderer] = useState(0);
-  const [map, setMap] = useState<kakao.maps.Map | null>(null); // 지도 객체
-  const [myMarker, setMyMarker] = useState<kakao.maps.Marker | null>(null); // 내 위치 마커
-  const [postMarker, setPostMarker] = useState<kakao.maps.Marker | null>(null); // 특정 포스트 마커
+  const [myPosition, setMyPosition] = useState({ latitude: '', longitude: '' });
 
   /* event handler - subPostMarker에 hover시 인포윈도우 띄우기 */
   const getSubPostInfo = (
     subMarker: kakao.maps.Marker,
-    map: kakao.maps.Map,
+    map: kakao.maps.Map | null,
     post: IPost,
     markPosition: kakao.maps.LatLng,
   ) => {
@@ -60,15 +60,15 @@ export const MapProvider = ({ children }: { children: React.ReactChild }) => {
   /* event handler - 지도 이동 시 지도 범위 내에 등록된 포스트 목록 조회 후 마커로 표시 */
   const debounce = (cb: Function, delay: number) => {
     let timer: any;
-    return (map: kakao.maps.Map) => {
+    return (map: kakao.maps.Map | null) => {
       if (timer) clearTimeout(timer);
       timer = setTimeout(cb, delay, map);
     };
   };
-  const getSubPosts = (map: kakao.maps.Map) => {
-    const bounds = map.getBounds();
-    const [swLat, swLng] = bounds?.getSouthWest().toString().slice(1, -1).split(',');
-    const [neLat, neLng] = bounds?.getNorthEast().toString().slice(1, -1).split(',');
+  const getSubPosts = (map: kakao.maps.Map | null) => {
+    const bounds = map?.getBounds();
+    const [swLat, swLng] = bounds?.getSouthWest().toString().slice(1, -1).split(',') ?? [];
+    const [neLat, neLng] = bounds?.getNorthEast().toString().slice(1, -1).split(',') ?? [];
     // console.log(swLat, swLng, neLat, neLng);
     fetcher(`/posts/bounds?swLat=${swLat}&swLng=${swLng.trim()}&neLat=${neLat}&neLng=${neLng.trim()}&tab=home`)
       .then((posts) => {
@@ -103,25 +103,35 @@ export const MapProvider = ({ children }: { children: React.ReactChild }) => {
       disableDoubleClickZoom: true,
     };
     /* 지도 생성 */
-    setMap((prev) => {
-      const newMap = new kakao.maps.Map(container, options);
-      getSubPosts(newMap);
-      newMap.setZoomable(false);
+    map = new kakao.maps.Map(container, options);
+    getSubPosts(map);
+    map?.setZoomable(false);
 
-      /* 내 위치 마커 생성 */
-      setMyMarker((prev) => {
-        const newMyMarker = new kakao.maps.Marker({ position, clickable: true });
-        newMyMarker.setMap(newMap);
-        // event-지도 클릭 시 내 위치 마커 이동
-        newMap.addListener('click', ({ latLng }: { latLng: kakao.maps.LatLng }) => {
-          newMyMarker.setPosition(latLng);
-          rerenderer((prev) => prev + 1);
-        });
-        // event-내 위치 마커 클릭 시 게시물 작성하기 모달 띄우기
-        newMyMarker.addListener('click', () => {
-          console.log(newMyMarker.getPosition());
-          // 게시물 작성 모달
-          const content = `
+    /* 내 위치 마커 생성 */
+    myMarker = new kakao.maps.Marker({ position, clickable: true });
+    setMyPosition((prev) => ({
+      latitude: myMarker?.getPosition().getLat().toFixed(6) ?? '',
+      longitude: myMarker?.getPosition().getLng().toFixed(6) ?? '',
+    }));
+    myMarker?.setMap(map);
+
+    /* 특정 포스트 마커 생성 */
+    postMarker = new kakao.maps.Marker({ position: new kakao.maps.LatLng(0, 0), clickable: true });
+    postMarker?.setZIndex(1);
+
+    // event-지도 클릭 시 내 위치 마커 이동
+    map?.addListener('click', ({ latLng }: { latLng: kakao.maps.LatLng }) => {
+      setMyPosition((prev) => ({ latitude: latLng.getLat().toFixed(6), longitude: latLng.getLng().toFixed(6) }));
+      myMarker?.setPosition(latLng);
+    });
+    // event-지도 이동 시 포스트 조회
+    map?.addListener('center_changed', () => dGetSubPosts(map));
+
+    // event-내 위치 마커 클릭 시 게시물 작성하기 모달 띄우기
+    myMarker?.addListener('click', () => {
+      console.log(myMarker?.getPosition());
+      // 게시물 작성 모달
+      const content = `
             <div style='background-color: black; color: white;'>
               <ul>
                 <li>이것은 테스트</li>
@@ -130,31 +140,16 @@ export const MapProvider = ({ children }: { children: React.ReactChild }) => {
               </ul>
             </div>
           `;
-          const overlay = new kakao.maps.CustomOverlay({
-            position: newMyMarker.getPosition(),
-            content,
-          });
-          overlay.setMap(newMap);
-        });
-        return newMyMarker;
+      const overlay = new kakao.maps.CustomOverlay({
+        position: myMarker?.getPosition(),
+        content,
       });
-
-      /* 특정 포스트 마커 생성 */
-      setPostMarker((prev) => {
-        const newPostMarker = new kakao.maps.Marker({ position: new kakao.maps.LatLng(0, 0), clickable: true });
-        newPostMarker.setZIndex(1);
-        return newPostMarker;
-      });
-
-      /* event-지도 이동 시 포스트 조회 */
-      newMap.addListener('center_changed', () => dGetSubPosts(newMap));
-      // getSubPosts(newMap);
-      return newMap;
+      overlay.setMap(map);
     });
   }, []);
 
   /* 중심 좌표 설정 및 마커 표시 */
-  const setMapCenter = (latitude: number, longitude: number, marker: kakao.maps.Marker) => {
+  const setMapCenter = (latitude: number, longitude: number, marker: kakao.maps.Marker | null) => {
     const position = new kakao.maps.LatLng(latitude, longitude);
     if (map && marker) {
       map.setCenter(position);
@@ -188,14 +183,7 @@ export const MapProvider = ({ children }: { children: React.ReactChild }) => {
   );
 
   /* 내가 찍은 마커 위치 가져오기 */
-  const getMyPosition = () => {
-    const myPosition = myMarker?.getPosition();
-    const latitude = myPosition?.getLat().toFixed(6);
-    const longitude = myPosition?.getLng().toFixed(6);
-    console.log('lat >>> ', latitude, 'lng >>> ', longitude);
-
-    return { latitude, longitude };
-  };
+  const getMyPosition = useCallback(() => myPosition, [myPosition]);
 
   return (
     <MapContext.Provider value={{ map, myMarker, initializeMap, moveCenterToMe, moveCenterToPost, getMyPosition }}>

--- a/contexts/infowindow/index.tsx
+++ b/contexts/infowindow/index.tsx
@@ -1,0 +1,28 @@
+export const showPostInfo = (title: string, postImg: string = '', content: string, like: number, userImg: string, nickname: string) => {
+  return `
+  <div style="background-color: gray; width: 270px; height: 160px; display: flex; flex-direction: column; border-radius: 5px; overflow: hidden">
+      <h2 style="background-color: lightblue; margin: 0; padding: 0; text-align: center">${title}</h2>
+      <div style="background-color: lightgray; display: flex; flex: 1">
+        <div style="display: flex; align-items: center ">
+          <img src=${postImg} alt="대표이미지" style="width: 90px; height: 90px" />
+        </div>
+        <div style="background-color: white; flex: 1; padding: 5px">
+          ${content}
+        </div>
+      </div>
+      <div style="display: flex; justify-content: space-between; align-items: center; height: 80px; padding: 5px">
+        <div>
+          조회수: ${like}
+        </div>
+        <div style="display: flex; align-items: center">
+          <div style="display: flex; align-items: center">
+            <img src=${userImg} style="width: 25px; height: 25px; border-radius: 50%" />
+          </div>
+          <div style="marginLeft: 3px">
+            ${nickname}
+          </div>
+        </div>
+      </div>
+    </div>
+  `;
+};

--- a/contexts/infowindow/index.tsx
+++ b/contexts/infowindow/index.tsx
@@ -7,7 +7,7 @@ export const showPostInfo = (
   nickname: string,
 ) => {
   return `
-  <div style="background-color: gray; width: 270px; height: 160px; display: flex; flex-direction: column; border-radius: 5px; overflow: hidden">
+  <div style="background-color: gray; width: 270px; height: 160px; display: flex; flex-direction: column; border-radius: 5px; overflow: hidden; z-index: 999">
       <h2 style="background-color: lightblue; margin: 0; padding: 0; text-align: center">${title}</h2>
       <div style="background-color: lightgray; display: flex; flex: 1">
         <div style="display: flex; align-items: center ">

--- a/contexts/infowindow/index.tsx
+++ b/contexts/infowindow/index.tsx
@@ -1,4 +1,11 @@
-export const showPostInfo = (title: string, postImg: string = '', content: string, like: number, userImg: string, nickname: string) => {
+export const showPostInfo = (
+  title: string,
+  postImg: string = '',
+  content: string,
+  like: number,
+  userImg: string,
+  nickname: string,
+) => {
   return `
   <div style="background-color: gray; width: 270px; height: 160px; display: flex; flex-direction: column; border-radius: 5px; overflow: hidden">
       <h2 style="background-color: lightblue; margin: 0; padding: 0; text-align: center">${title}</h2>

--- a/contexts/infowindow/index.tsx
+++ b/contexts/infowindow/index.tsx
@@ -7,11 +7,11 @@ export const showPostInfo = (
   nickname: string,
 ) => {
   return `
-  <div style="background-color: gray; width: 270px; height: 160px; display: flex; flex-direction: column; border-radius: 5px; overflow: hidden; z-index: 999">
+  <div style="background-color: gray; width: 270px; height: 160px; display: flex; flex-direction: column; border-radius: 5px; overflow: hidden;">
       <h2 style="background-color: lightblue; margin: 0; padding: 0; text-align: center">${title}</h2>
       <div style="background-color: lightgray; display: flex; flex: 1">
         <div style="display: flex; align-items: center ">
-          <img src=${postImg} alt="대표이미지" style="width: 90px; height: 90px" />
+          <img src=${postImg} alt="대표 미지" style="width: 90px; height: 90px" />
         </div>
         <div style="background-color: white; flex: 1; padding: 5px">
           ${content}

--- a/contexts/mapconatextemp.tsx
+++ b/contexts/mapconatextemp.tsx
@@ -1,0 +1,208 @@
+/**
+ *
+ * 삭제 예정입니다.
+ *
+ */
+// import React, { createContext, useContext, useState, useCallback } from 'react';
+// import { useNavigate } from 'react-router-dom';
+// import fetcher from '@utils/fetcher';
+// import { IPost } from '@typings/db';
+// import { showPostInfo } from './infowindow';
+// const { kakao } = window;
+
+// interface IMapContext {
+//   map: kakao.maps.Map | null;
+//   myMarker: kakao.maps.Marker | null;
+//   initializeMap: (container: HTMLElement, latitude: number, longitude: number) => void;
+//   moveCenterToMe: () => void;
+//   moveCenterToPost: (latitude: number, longitude: number) => void;
+//   getMyPosition: () => { latitude: string | undefined; longitude: string | undefined };
+// }
+
+// const MapContext = createContext<IMapContext>({
+//   map: null,
+//   myMarker: null,
+//   initializeMap: (container: HTMLElement, latitude: number, longitude: number) => {},
+//   moveCenterToMe: () => {},
+//   moveCenterToPost: (latitude: number, longitude: number) => {},
+//   getMyPosition: () => ({ latitude: '', longitude: '' }),
+// });
+
+// export const MapProvider = ({ children }: { children: React.ReactChild }) => {
+//   const navigate = useNavigate();
+//   const [map, setMap] = useState<kakao.maps.Map | null>(null); // 지도 객체
+//   const [myMarker, setMyMarker] = useState<kakao.maps.Marker | null>(null); // 내 위치 마커
+//   const [postMarker, setPostMarker] = useState<kakao.maps.Marker | null>(null); // 특정 포스트 마커
+
+//   /* event handler - subPostMarker에 hover시 인포윈도우 띄우기 */
+//   const getSubPostInfo = (
+//     subMarker: kakao.maps.Marker,
+//     map: kakao.maps.Map,
+//     post: IPost,
+//     markPosition: kakao.maps.LatLng,
+//   ) => {
+//     const infoPosition = new kakao.maps.LatLng((markPosition.getLat() + 0.001).toFixed(6), markPosition.getLng());
+//     const content = showPostInfo(
+//       post.title,
+//       post.Images[0]?.src,
+//       post.content,
+//       post.hits,
+//       post.User.profile_image_url,
+//       post.User.nickname,
+//     );
+//     const overlay = new kakao.maps.CustomOverlay({
+//       content,
+//       map,
+//       position: infoPosition,
+//     });
+//     overlay.setMap(map);
+
+//     subMarker.addListener('mouseout', () => overlay.setMap(null));
+//   };
+
+//   /* event handler - 지도 이동 시 지도 범위 내에 등록된 포스트 목록 조회 후 마커로 표시 */
+//   const debounce = (cb: Function, delay: number) => {
+//     let timer: any;
+//     return (map: kakao.maps.Map) => {
+//       if (timer) clearTimeout(timer);
+//       timer = setTimeout(cb, delay, map);
+//     };
+//   };
+//   const getSubPosts = (map: kakao.maps.Map) => {
+//     const bounds = map.getBounds();
+//     const [swLat, swLng] = bounds?.getSouthWest().toString().slice(1, -1).split(',');
+//     const [neLat, neLng] = bounds?.getNorthEast().toString().slice(1, -1).split(',');
+//     // console.log(swLat, swLng, neLat, neLng);
+//     fetcher(`/posts/bounds?swLat=${swLat}&swLng=${swLng.trim()}&neLat=${neLat}&neLng=${neLng.trim()}&tab=home`)
+//       .then((posts) => {
+//         console.log(posts);
+//         const imageSrc = 'https://t1.daumcdn.net/localimg/localimages/07/mapapidoc/markerStar.png';
+//         const imageSize = new kakao.maps.Size(20, 32);
+//         const markerImage = new kakao.maps.MarkerImage(imageSrc, imageSize);
+//         posts.forEach((post: IPost) => {
+//           const position = new kakao.maps.LatLng(Number(post.latitude), Number(post.longitude));
+//           const subMarker = new kakao.maps.Marker({
+//             map,
+//             position,
+//             image: markerImage,
+//           });
+//           // event - 주변 포스트 마커 hover 시 인포윈도우 띄우기
+//           subMarker.addListener('mouseover', () => getSubPostInfo(subMarker, map, post, position));
+//           // event - 주변 포스트 마커 클릭 시 포스트 상세 페이지로 이동
+//           subMarker.addListener('click', () => navigate(`/posts/${post.id}`));
+//         });
+//       })
+//       .catch((err) => console.error(err));
+//   };
+//   const dGetSubPosts = debounce(getSubPosts, 500);
+
+//   /* 지도 및 마커 초기화 - 지도 생성, 중심 좌표를 내 위치로 설정, 내 위치 마커 생성 및 표시 */
+//   const initializeMap = useCallback((container: HTMLElement, latitude: number, longitude: number) => {
+//     console.log('Map Initialized!!!!!@@@@!!!!!!');
+//     const position = new kakao.maps.LatLng(latitude, longitude);
+//     const options = {
+//       center: position,
+//       level: 3,
+//       disableDoubleClickZoom: true,
+//     };
+//     /* 지도 생성 */
+//     setMap((prev) => {
+//       const newMap = new kakao.maps.Map(container, options);
+//       getSubPosts(newMap);
+//       newMap.setZoomable(false);
+
+//       /* 내 위치 마커 생성 */
+//       setMyMarker((prev) => {
+//         const newMyMarker = new kakao.maps.Marker({ position, clickable: true });
+//         newMyMarker.setMap(newMap);
+//         // event-지도 클릭 시 내 위치 마커 이동
+//         newMap.addListener('click', ({ latLng }: { latLng: kakao.maps.LatLng }) => {
+//           newMyMarker.setPosition(latLng);
+//         });
+//         // event-내 위치 마커 클릭 시 게시물 작성하기 모달 띄우기
+//         newMyMarker.addListener('click', () => {
+//           console.log(newMyMarker.getPosition());
+//           // 게시물 작성 모달
+//           const content = `
+//             <div style='background-color: black; color: white;'>
+//               <ul>
+//                 <li>이것은 테스트</li>
+//                 <li>안녕하시오.</li>
+//                 <li>안녕하가시오.</li>
+//               </ul>
+//             </div>
+//           `;
+//           const overlay = new kakao.maps.CustomOverlay({
+//             position: newMyMarker.getPosition(),
+//             content,
+//           });
+//           overlay.setMap(newMap);
+//         });
+//         return newMyMarker;
+//       });
+
+//       /* 특정 포스트 마커 생성 */
+//       setPostMarker((prev) => {
+//         const newPostMarker = new kakao.maps.Marker({ position: new kakao.maps.LatLng(0, 0), clickable: true });
+//         newPostMarker.setZIndex(1);
+//         return newPostMarker;
+//       });
+
+//       /* event-지도 이동 시 포스트 조회 */
+//       newMap.addListener('center_changed', () => dGetSubPosts(newMap));
+//       // getSubPosts(newMap);
+//       return newMap;
+//     });
+//   }, []);
+
+//   /* 중심 좌표 설정 및 마커 표시 */
+//   const setMapCenter = (latitude: number, longitude: number, marker: kakao.maps.Marker) => {
+//     const position = new kakao.maps.LatLng(latitude, longitude);
+//     if (map && marker) {
+//       map.setCenter(position);
+//       marker.setPosition(position);
+//       marker.setMap(map);
+//     }
+//   };
+
+//   /* 내 위치로 지도 중심 좌표 변경 with 내 위치 마커 */
+//   const moveCenterToMe = useCallback(() => {
+//     if (map && myMarker) {
+//       const onSuccess = ({ coords: { latitude, longitude } }: { coords: { latitude: number; longitude: number } }) => {
+//         setMapCenter(latitude, longitude, myMarker);
+//       };
+//       const onError = (error: any) => {
+//         console.error(error);
+//       };
+//       navigator?.geolocation.getCurrentPosition(onSuccess, onError);
+//     }
+//   }, [map, myMarker]);
+
+//   /* 특정 포스트 위치로 지도 중심 좌표 변경 with 특정 포스트 마커 */
+//   const moveCenterToPost = useCallback(
+//     (latitude: number, longitude: number) => {
+//       if (map && postMarker) {
+//         postMarker.setMap(null);
+//         setMapCenter(latitude, longitude, postMarker);
+//       }
+//     },
+//     [map, postMarker],
+//   );
+
+//   /* 내가 찍은 마커 위치 가져오기 */
+//   const getMyPosition = useCallback(() => {
+//     const myPosition = myMarker?.getPosition();
+//     const latitude = myPosition?.getLat().toFixed(6);
+//     const longitude = myPosition?.getLng().toFixed(6);
+//     console.log('lat >>> ', latitude, 'lng >>> ', longitude);
+
+//     return { latitude, longitude };
+//   }, [myMarker]);
+
+//   return (
+//     <MapContext.Provider value={{ map, myMarker, initializeMap, moveCenterToMe, moveCenterToPost, getMyPosition }}>
+//       {children}
+//     </MapContext.Provider>
+//   );
+// };
+// export const useMap = () => useContext(MapContext);

--- a/layouts/App/index.tsx
+++ b/layouts/App/index.tsx
@@ -22,7 +22,7 @@ const Intro = loadable(() => import('@pages/Intro'));
 const Introduce = loadable(() => import('@pages/Introduce'));
 const PostsEdit = loadable(() => import('@pages/PostsEdit'));
 const ProfileEdit = loadable(() => import('@pages/ProfileEdit'));
-const NotFound = loadable(() => import('@pages/NotFound'));
+// const NotFound = loadable(() => import('@pages/NotFound'));
 
 const App = () => {
   return (
@@ -50,7 +50,7 @@ const App = () => {
         <Route path={'/posts/:postId'} element={<PostsDetail />} />
         <Route path={'/posts/new'} element={<PostsNew />} />
         <Route path={'/introduce'} element={<Introduce />} />
-        <Route path={'/#notfound'} element={<NotFound />} />
+        {/* <Route path={'/#notfound'} element={<NotFound />} /> */}
       </Routes>
     </AppLayout>
   );

--- a/layouts/App/index.tsx
+++ b/layouts/App/index.tsx
@@ -22,12 +22,13 @@ const Intro = loadable(() => import('@pages/Intro'));
 const Introduce = loadable(() => import('@pages/Introduce'));
 const PostsEdit = loadable(() => import('@pages/PostsEdit'));
 const ProfileEdit = loadable(() => import('@pages/ProfileEdit'));
+const Map = loadable(() => import('@components/Map'));
 // const NotFound = loadable(() => import('@pages/NotFound'));
 
 const App = () => {
   return (
-    <AppLayout>
-      <Routes>
+    <Routes>
+      <Route path="/" element={<AppLayout />}>
         <Route index element={<Home />} />
         <Route path={'/home'} element={<Home />} />
         <Route path={'/explore'} element={<Explore />} />
@@ -43,16 +44,16 @@ const App = () => {
         <Route path={'/:userId/edit'} element={<ProfileEdit />} />
         <Route path={'/chatrooms'} element={<Chatrooms />} />
         <Route path={'/chatrooms/:chatroomId'} element={<Chatrooms />} />
-        <Route path={'/intro'} element={<Intro />} />
         <Route path={'/settings'} element={<Settings />} />
         <Route path={'/more'} element={<More />} />
         <Route path={'/posts/:postId/edit'} element={<PostsEdit />} />
         <Route path={'/posts/:postId'} element={<PostsDetail />} />
         <Route path={'/posts/new'} element={<PostsNew />} />
-        <Route path={'/introduce'} element={<Introduce />} />
-        {/* <Route path={'/#notfound'} element={<NotFound />} /> */}
-      </Routes>
-    </AppLayout>
+      </Route>
+      <Route path={'/intro'} element={<Intro />} />
+      <Route path={'/introduce'} element={<Introduce />} />
+      {/* <Route path={'/#notfound'} element={<NotFound />} /> */}
+    </Routes>
   );
 };
 

--- a/layouts/AppLayout/index.tsx
+++ b/layouts/AppLayout/index.tsx
@@ -3,10 +3,10 @@ import styled from '@emotion/styled';
 import { ThemeProvider } from '@emotion/react';
 import { theme } from '../../themes/themes';
 import { IoIosArrowBack, IoIosArrowForward } from 'react-icons/io';
-import { useLocation } from 'react-router-dom';
+import { Outlet, useLocation } from 'react-router-dom';
 import Map from '@components/Map/index';
 import SideNavigation from '@components/revised/common/navigations/SideNavigation';
-import { MapProvider } from '@contexts/MapContext';
+import { MapProvider } from '@contexts/Map/MapContext';
 
 interface IProps {
   children: React.ReactNode;
@@ -61,34 +61,33 @@ export const MapZone = styled.div`
   background-color: #fff;
 `;
 
-const AppLayout: FC<IProps> = ({ children }) => {
+const AppLayout = () => {
   const location = useLocation();
   const [showPage, toggleShowPage] = useReducer((show) => !show, true);
   return (
     <ThemeProvider theme={theme}>
       <Layout>
-        {['/intro', '/introduce'].includes(location.pathname) || location.hash === '#notfound' ? (
-          <div>{children}</div>
-        ) : (
-          <MapProvider>
-            <>
-              <div
-                onClick={() => {
-                  if (!showPage) toggleShowPage();
-                }}
-              >
-                <SideNavigation />
-              </div>
-              <MainPage show={showPage}>{children}</MainPage>
-              <MapZone>
-                <Map />
-              </MapZone>
-              <SlideButton show={showPage} onClick={toggleShowPage}>
-                {showPage ? <IoIosArrowBack /> : <IoIosArrowForward />}
-              </SlideButton>
-            </>
-          </MapProvider>
-        )}
+        <MapProvider>
+          <>
+            <div
+              onClick={() => {
+                if (!showPage) toggleShowPage();
+              }}
+            >
+              <SideNavigation />
+            </div>
+            <MapZone>
+              <Map />
+            </MapZone>
+            <MainPage show={showPage}>
+              <Outlet />
+            </MainPage>
+
+            <SlideButton show={showPage} onClick={toggleShowPage}>
+              {showPage ? <IoIosArrowBack /> : <IoIosArrowForward />}
+            </SlideButton>
+          </>
+        </MapProvider>
       </Layout>
     </ThemeProvider>
   );

--- a/pages/Explore/index.tsx
+++ b/pages/Explore/index.tsx
@@ -6,7 +6,7 @@ import { useForm } from 'react-hook-form';
 import queryString from 'query-string';
 import axios from 'axios';
 import FixedHeader from '@components/common/headers/FixedHeader';
-import { useMap } from '@contexts/MapContext';
+import { useMap } from '@contexts/Map/MapContext';
 
 export const Base = styled.div`
   width: 100%;

--- a/pages/Home/index.tsx
+++ b/pages/Home/index.tsx
@@ -9,7 +9,7 @@ import { v4 as uuid } from 'uuid';
 import TopNavigation from '@components/revised/common/navigations/TopNavigation';
 import { redirect, useNavigate, useLocation } from 'react-router-dom';
 import readable from '@utils/readable';
-import { useMap } from '@contexts/MapContext';
+import { useMap } from '@contexts/Map/MapContext';
 
 export const Base = styled.div`
   width: 100%;

--- a/pages/Intro/index.tsx
+++ b/pages/Intro/index.tsx
@@ -53,7 +53,7 @@ const Intro = () => {
   const baseUrl = 'http://localhost:8080';
   const { data: md, mutate: mutateMd } = useSWR('/users/me', fetcher);
 
-  if (md) navigate('/');
+  // if (md) navigate('/');
 
   return (
     <Base>

--- a/pages/PostsDetail/index.tsx
+++ b/pages/PostsDetail/index.tsx
@@ -23,7 +23,6 @@ import TapItem from '@components/revised/Profile/TapList/TapItem';
 import { HiOutlineLocationMarker } from 'react-icons/hi';
 import TapList from '@components/revised/Profile/TapList';
 import HoverLabel from '@components/common/labels/HoverLabel';
-import { useMap } from '@contexts/MapContext';
 import compose from '@utils/compose';
 import readable from '@utils/readable';
 import handleNavigate from '@utils/handleNavigate';
@@ -112,13 +111,8 @@ const PostDetail = () => {
   const { data: userPd } = useSWR<IPost[]>(`/users/${pd?.User.id}/posts`, fetcher);
   const copyUrlRef = useRef<HTMLTextAreaElement | null>(null);
   const [showModals, handleModal] = useModals('showSettingsModal', 'showEachTapSettingsModal', 'showImagesZoomModal');
-  const { moveCenterToPost } = useMap();
 
   // console.log('🌷', pd);
-
-  if (pd && moveCenterToPost) {
-    moveCenterToPost(Number(pd.latitude), Number(pd.longitude));
-  }
 
   const copyUrl = (e: any) => {
     copyUrlRef.current?.select();

--- a/pages/PostsDetail/index.tsx
+++ b/pages/PostsDetail/index.tsx
@@ -23,7 +23,7 @@ import TapItem from '@components/revised/Profile/TapList/TapItem';
 import { HiOutlineLocationMarker } from 'react-icons/hi';
 import TapList from '@components/revised/Profile/TapList';
 import HoverLabel from '@components/common/labels/HoverLabel';
-import { useMap } from '@contexts/MapContext';
+import { useMap } from '@contexts/Map/MapContext';
 import compose from '@utils/compose';
 import readable from '@utils/readable';
 import handleNavigate from '@utils/handleNavigate';

--- a/pages/PostsDetail/index.tsx
+++ b/pages/PostsDetail/index.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useRef } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef } from 'react';
 import styled from '@emotion/styled';
 import DetailTopNavigation from '@components/revised/common/navigations/DetailTopNavigation';
 import { Link, useNavigate, useParams } from 'react-router-dom';
@@ -23,6 +23,7 @@ import TapItem from '@components/revised/Profile/TapList/TapItem';
 import { HiOutlineLocationMarker } from 'react-icons/hi';
 import TapList from '@components/revised/Profile/TapList';
 import HoverLabel from '@components/common/labels/HoverLabel';
+import { useMap } from '@contexts/MapContext';
 import compose from '@utils/compose';
 import readable from '@utils/readable';
 import handleNavigate from '@utils/handleNavigate';
@@ -111,6 +112,7 @@ const PostDetail = () => {
   const { data: userPd } = useSWR<IPost[]>(`/users/${pd?.User.id}/posts`, fetcher);
   const copyUrlRef = useRef<HTMLTextAreaElement | null>(null);
   const [showModals, handleModal] = useModals('showSettingsModal', 'showEachTapSettingsModal', 'showImagesZoomModal');
+  const { moveCenterToPost } = useMap();
 
   // console.log('🌷', pd);
 
@@ -153,6 +155,12 @@ const PostDetail = () => {
   const postImageStyle = { width: '100%', height: '100%', borderRadius: 0, border: 'none' };
 
   const exceptCurrentPost = (posts: IPost[]) => posts.filter((item) => item.id !== Number(postId));
+
+  useEffect(() => {
+    if (pd) {
+      moveCenterToPost(Number(pd.latitude), Number(pd.longitude));
+    }
+  }, [pd]);
 
   if (pd === undefined) return <div>로딩중...</div>;
 

--- a/pages/PostsNew/index.tsx
+++ b/pages/PostsNew/index.tsx
@@ -23,6 +23,7 @@ import TitleNavigation from '@components/revised/common/navigations/TitleNavigat
 import handleNavigate from '@utils/handleNavigate';
 import { Base as B, MainContentZone as M } from '@pages/Home';
 import { IHashtag, IMention } from '@typings/db';
+import { useMap } from '@contexts/MapContext';
 
 export const Base = styled(B)`
   width: 100%;
@@ -85,7 +86,9 @@ export const makeMentions = (data: string) =>
   });
 
 const PostsNew = () => {
+  const { getMyPosition } = useMap();
   const navigator = useNavigate();
+  const { latitude, longitude } = getMyPosition();
   const { data: ud, mutate: mutateUd } = useSWR(`/users/me`, fetcher);
   const {
     control,
@@ -97,8 +100,8 @@ const PostsNew = () => {
       title: '',
       content: '',
       is_private: false,
-      longitude: '126.111111',
-      latitude: '37.222222',
+      longitude: latitude,
+      latitude: longitude,
       images: [],
       // hashtags: [{ content: 'hello' }, { content: 'hello2' }],
       // mentions: [{ receiver: 7 }, { receiver: 18 }, { receiver: 19 }],
@@ -114,7 +117,7 @@ const PostsNew = () => {
     setShowOptions((p) => ({ ...p, [option]: !p[option] }));
   }, []);
 
-  const { title, images, longitude, latitude } = watch();
+  const { title, images } = watch();
   const isSubmitAvailable = Boolean(title) && Boolean(longitude) && Boolean(latitude);
   const onSubmit = handleSubmit(async (data: IPostForm) => {
     let filenames;
@@ -129,6 +132,8 @@ const PostsNew = () => {
     const newPost = await axios
       .post('/posts', {
         ...data,
+        latitude,
+        longitude,
         hashtags: makeHashtags(data.content),
         mentions: makeMentions(data.content),
         images: filenames || [],

--- a/pages/PostsNew/index.tsx
+++ b/pages/PostsNew/index.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import styled from '@emotion/styled';
 import { useForm } from 'react-hook-form';
 import { useNavigate } from 'react-router-dom';

--- a/pages/PostsNew/index.tsx
+++ b/pages/PostsNew/index.tsx
@@ -23,7 +23,7 @@ import TitleNavigation from '@components/revised/common/navigations/TitleNavigat
 import handleNavigate from '@utils/handleNavigate';
 import { Base as B, MainContentZone as M } from '@pages/Home';
 import { IHashtag, IMention } from '@typings/db';
-import { useMap } from '@contexts/MapContext';
+import { useMap } from '@contexts/Map/MapContext';
 
 export const Base = styled(B)`
   width: 100%;

--- a/utils/debounce.ts
+++ b/utils/debounce.ts
@@ -1,0 +1,8 @@
+const debounce = (cb: Function, dealy: number) => {
+  let timer: any;
+  return (...args: any[]) => {
+    if (timer) clearTimeout(timer);
+    timer = setTimeout(cb, dealy, ...args);
+  };
+};
+export default debounce;


### PR DESCRIPTION
주변 포스트 마커에 mouseover 시 간략한 포스트 정보를 인포윈도우로 보여줍니다.
주변 포스트 마커 click 시 해당 포스트 상세 페이지로 이동합니다.

기존에 지도를 드래그해서 주변 포스트 목록 조회 요청을 보내는 함수에 디바운스를 걸어 중심 좌표 변경 이벤트에 걸었습니다.